### PR TITLE
fix: accept scalar n_lags in MLproject schema

### DIFF
--- a/MLproject
+++ b/MLproject
@@ -7,11 +7,11 @@ supported_period_type: any
 allow_free_additional_continuous_covariates: true
 user_options:
   n_lags:
-    type: array
+    type: [array, integer]
     items:
       type: integer
     default: [3]
-    description: Number of lags per covariate, in the same order as additional_continuous_covariates. A single value applies to all covariates.
+    description: Number of lags per covariate, in the same order as additional_continuous_covariates. A single integer broadcasts to all covariates.
   precision:
     type: number
     default: 0.01


### PR DESCRIPTION
## Summary

Widens the `n_lags` user-option type from `array` to `[array, integer]` so that both forms validate:

```yaml
n_lags: 3        # broadcasts to all covariates
n_lags: [3, 6]   # one lag per covariate, in declared order
```

## Why

The R model in `predict.R` already broadcasts a length-1 lag list across all covariates (`if(length(nlag) < length(covariates)) {nlag <- rep(nlag, ...)}`), so a scalar is functionally valid. The schema was the only thing rejecting it.

Concretely, this came up while bumping the chap-core seeded default to v5: existing seed configs use `n_lags: 3` and were being rejected by jsonschema validation at startup.

## Test plan

- [ ] `n_lags: 3`, `n_lags: [3]`, and `n_lags: [3, 6]` all validate.
- [ ] `n_lags: "x"` still fails validation.